### PR TITLE
Abstract data layer

### DIFF
--- a/src/context/base-repository.ts
+++ b/src/context/base-repository.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { BaseEntity, DataSource, EntityTarget, Repository, SelectQueryBuilder } from "typeorm";
+import GraphQLDatabaseLoader, {
+  EjectQueryCallback,
+  GraphQLQueryBuilder
+} from "@mando75/typeorm-graphql-loader";
+import { FindManyParams, FindOneParams, IRepository } from "./repository-interface";
+
+export type RepositoryDataContext = {
+  dataSource: DataSource;
+  graphQLDataLoader: GraphQLDatabaseLoader;
+};
+
+export class BaseRepository<T extends BaseEntity> implements IRepository<T> {
+  protected readonly repository!: Repository<T>;
+  protected readonly dataSource!: DataSource;
+
+  protected readonly createGraphQLQueryBuilder!: () => GraphQLQueryBuilder<any>;
+  protected readonly alias!: string;
+
+  constructor(entity: EntityTarget<T>, alias: string, context: RepositoryDataContext) {
+    this.alias = alias;
+    this.dataSource = context.dataSource;
+    this.repository = context.dataSource.getRepository(entity);
+    this.createGraphQLQueryBuilder = () =>
+      context.graphQLDataLoader.loadEntity(entity as any, alias);
+  }
+
+  protected createQueryBuilder(): SelectQueryBuilder<T> {
+    return this.repository.createQueryBuilder(this.alias);
+  }
+
+  public async find(options: FindManyParams<T>): Promise<T[]> {
+    return this.findBase(options);
+  }
+
+  public async first(options: FindOneParams<T>): Promise<T | null> {
+    return this.firstBase(options);
+  }
+
+  protected findBase(
+    options: FindManyParams<T>,
+    queryCallback?: EjectQueryCallback<T>
+  ): Promise<T[]> {
+    if (options.resolverInfo) {
+      return this.createGraphQLQueryBuilder()
+        .info(options.resolverInfo)
+        .ejectQueryBuilder((query) => {
+          query = query
+            .where(options.where || {})
+            .skip(options.skip)
+            .take(options.take);
+
+          return queryCallback ? queryCallback(query) : query;
+        })
+        .loadMany();
+    }
+
+    const query = this.createQueryBuilder()
+      .where(options.where || {})
+      .skip(options.skip)
+      .take(options.take);
+    return (queryCallback ? queryCallback(query) : query).getMany();
+  }
+
+  protected firstBase(
+    options: FindOneParams<T>,
+    queryCallback?: EjectQueryCallback<T>
+  ): Promise<T | null> {
+    if (options.resolverInfo) {
+      return this.createGraphQLQueryBuilder()
+        .info(options.resolverInfo)
+        .ejectQueryBuilder((query) => {
+          query = query.where(options.where || {});
+          return queryCallback ? queryCallback(query) : query;
+        })
+        .loadOne();
+    }
+
+    const query = this.createQueryBuilder().where(options.where || {});
+    return (queryCallback ? queryCallback(query) : query).getOne();
+  }
+}

--- a/src/context/box-repository.ts
+++ b/src/context/box-repository.ts
@@ -1,11 +1,10 @@
 import { AssetEntity, BoxEntity, InputEntity, TokenEntity } from "../entities";
-import { Box } from "../graphql";
 import { removeUndefined } from "../utils";
 import { BaseRepository, RepositoryDataContext } from "./base-repository";
 
 export class BoxRepository extends BaseRepository<BoxEntity> {
   constructor(context: RepositoryDataContext) {
-    super(Box, "box", context);
+    super(BoxEntity, "box", context, { mainChain: true });
   }
 
   public async sum(options: {

--- a/src/context/box-repository.ts
+++ b/src/context/box-repository.ts
@@ -1,8 +1,13 @@
 import { AssetEntity, BoxEntity, InputEntity, TokenEntity } from "../entities";
+import { Box } from "../graphql";
 import { removeUndefined } from "../utils";
-import { BaseRepository } from "./base-repository";
+import { BaseRepository, RepositoryDataContext } from "./base-repository";
 
 export class BoxRepository extends BaseRepository<BoxEntity> {
+  constructor(context: RepositoryDataContext) {
+    super(Box, "box", context);
+  }
+
   public async sum(options: {
     where: { address: string; maxHeight?: number };
     include: { nanoErgs: boolean; assets: boolean };

--- a/src/context/box-repository.ts
+++ b/src/context/box-repository.ts
@@ -1,0 +1,47 @@
+import { AssetEntity, BoxEntity, InputEntity, TokenEntity } from "../entities";
+import { removeUndefined } from "../utils";
+import { BaseRepository } from "./base-repository";
+
+export class BoxRepository extends BaseRepository<BoxEntity> {
+  public async sum(options: {
+    where: { address: string; maxHeight?: number };
+    include: { nanoErgs: boolean; assets: boolean };
+  }) {
+    let baseQuery = this.repository
+      .createQueryBuilder("box")
+      .leftJoinAndSelect(InputEntity, "input", "box.boxId = input.boxId")
+      .where("box.address = :address")
+      .andWhere("input.boxId IS NULL")
+      .setParameters(
+        removeUndefined({
+          address: options.where.address,
+          height: options.where.maxHeight
+        })
+      );
+
+    if (options.where.maxHeight) {
+      baseQuery = baseQuery.andWhere("box.creationHeight <= :height");
+    }
+
+    const { nanoErgs } = options.include.nanoErgs
+      ? await baseQuery.select("SUM(box.value)", "nanoErgs").getRawOne()
+      : 0;
+
+    const assets = options.include.assets
+      ? await baseQuery
+          .leftJoinAndSelect(AssetEntity, "asset", "box.boxId = asset.boxId")
+          .leftJoinAndSelect(TokenEntity, "token", "asset.tokenId = token.tokenId")
+          .andWhere("asset.tokenId IS NOT NULL")
+          .groupBy("asset.tokenId")
+          .addGroupBy("token.name")
+          .addGroupBy("token.decimals")
+          .select("sum(asset.value)", "amount")
+          .addSelect("asset.tokenId", "tokenId")
+          .addSelect("token.name", "name")
+          .addSelect("token.decimals", "decimals")
+          .getRawMany()
+      : [];
+
+    return { nanoErgs: nanoErgs ?? 0, assets };
+  }
+}

--- a/src/context/database-context.ts
+++ b/src/context/database-context.ts
@@ -31,11 +31,11 @@ export class DatabaseContext {
     };
 
     this.transactions = new TransactionRepository(context);
-    this.blockInfo = new BaseRepository(BlockInfoEntity, "block", context);
+    this.blockInfo = new BaseRepository(BlockInfoEntity, "block", context, { mainChain: true });
     this.boxes = new BoxRepository(context);
-    this.dataInputs = new BaseRepository(DataInputEntity, "data-input", context);
-    this.inputs = new BaseRepository(InputEntity, "input", context);
-    this.headers = new BaseRepository(HeaderEntity, "header", context);
+    this.dataInputs = new BaseRepository(DataInputEntity, "dti", context, { mainChain: true });
+    this.inputs = new BaseRepository(InputEntity, "input", context, { mainChain: true });
+    this.headers = new BaseRepository(HeaderEntity, "header", context, { mainChain: true });
     this.tokens = new BaseRepository(TokenEntity, "token", context);
 
     this.unconfirmedTransactions = new UnconfirmedTransactionRepository(context);

--- a/src/context/database-context.ts
+++ b/src/context/database-context.ts
@@ -1,0 +1,40 @@
+import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
+import { DataSource } from "typeorm";
+import {
+  BlockInfoEntity,
+  BoxEntity,
+  DataInputEntity,
+  HeaderEntity,
+  InputEntity,
+  TokenEntity,
+  TransactionEntity
+} from "../entities";
+import { BaseRepository } from "./base-repository";
+import { BoxRepository } from "./box-repository";
+import { IRepository } from "./repository-interface";
+import { TransactionsRepository } from "./transactions-repository";
+
+export class DatabaseContext {
+  public readonly transactions!: TransactionsRepository;
+  public readonly blockInfo!: IRepository<BlockInfoEntity>;
+  public readonly boxes!: BoxRepository;
+  public readonly dataInputs!: IRepository<DataInputEntity>;
+  public readonly inputs!: IRepository<InputEntity>;
+  public readonly headers!: IRepository<HeaderEntity>;
+  public readonly tokens!: IRepository<TokenEntity>;
+
+  constructor(dataSource: DataSource) {
+    const context = {
+      dataSource,
+      graphQLDataLoader: new GraphQLDatabaseLoader(dataSource)
+    };
+
+    this.transactions = new TransactionsRepository(TransactionEntity, "tx", context);
+    this.blockInfo = new BaseRepository(BlockInfoEntity, "block", context);
+    this.boxes = new BoxRepository(BoxEntity, "box", context);
+    this.dataInputs = new BaseRepository(DataInputEntity, "data-input", context);
+    this.inputs = new BaseRepository(InputEntity, "input", context);
+    this.headers = new BaseRepository(HeaderEntity, "header", context);
+    this.tokens = new BaseRepository(TokenEntity, "token", context);
+  }
+}

--- a/src/context/database-context.ts
+++ b/src/context/database-context.ts
@@ -2,13 +2,10 @@ import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { DataSource } from "typeorm";
 import {
   BlockInfoEntity,
-  BoxEntity,
   DataInputEntity,
   HeaderEntity,
   InputEntity,
-  TokenEntity,
-  TransactionEntity,
-  UnconfirmedTransactionEntity
+  TokenEntity
 } from "../entities";
 import { BaseRepository } from "./base-repository";
 import { BoxRepository } from "./box-repository";
@@ -33,18 +30,14 @@ export class DatabaseContext {
       graphQLDataLoader: new GraphQLDatabaseLoader(dataSource)
     };
 
-    this.transactions = new TransactionRepository(TransactionEntity, "tx", context);
+    this.transactions = new TransactionRepository(context);
     this.blockInfo = new BaseRepository(BlockInfoEntity, "block", context);
-    this.boxes = new BoxRepository(BoxEntity, "box", context);
+    this.boxes = new BoxRepository(context);
     this.dataInputs = new BaseRepository(DataInputEntity, "data-input", context);
     this.inputs = new BaseRepository(InputEntity, "input", context);
     this.headers = new BaseRepository(HeaderEntity, "header", context);
     this.tokens = new BaseRepository(TokenEntity, "token", context);
 
-    this.unconfirmedTransactions = new UnconfirmedTransactionRepository(
-      UnconfirmedTransactionEntity,
-      "utx",
-      context
-    );
+    this.unconfirmedTransactions = new UnconfirmedTransactionRepository(context);
   }
 }

--- a/src/context/database-context.ts
+++ b/src/context/database-context.ts
@@ -7,15 +7,17 @@ import {
   HeaderEntity,
   InputEntity,
   TokenEntity,
-  TransactionEntity
+  TransactionEntity,
+  UnconfirmedTransactionEntity
 } from "../entities";
 import { BaseRepository } from "./base-repository";
 import { BoxRepository } from "./box-repository";
 import { IRepository } from "./repository-interface";
-import { TransactionsRepository } from "./transactions-repository";
+import { TransactionRepository } from "./transactions-repository";
+import { UnconfirmedTransactionRepository } from "./unconfirmed-transactions-repository";
 
 export class DatabaseContext {
-  public readonly transactions!: TransactionsRepository;
+  public readonly transactions!: TransactionRepository;
   public readonly blockInfo!: IRepository<BlockInfoEntity>;
   public readonly boxes!: BoxRepository;
   public readonly dataInputs!: IRepository<DataInputEntity>;
@@ -23,18 +25,26 @@ export class DatabaseContext {
   public readonly headers!: IRepository<HeaderEntity>;
   public readonly tokens!: IRepository<TokenEntity>;
 
+  public readonly unconfirmedTransactions!: UnconfirmedTransactionRepository;
+
   constructor(dataSource: DataSource) {
     const context = {
       dataSource,
       graphQLDataLoader: new GraphQLDatabaseLoader(dataSource)
     };
 
-    this.transactions = new TransactionsRepository(TransactionEntity, "tx", context);
+    this.transactions = new TransactionRepository(TransactionEntity, "tx", context);
     this.blockInfo = new BaseRepository(BlockInfoEntity, "block", context);
     this.boxes = new BoxRepository(BoxEntity, "box", context);
     this.dataInputs = new BaseRepository(DataInputEntity, "data-input", context);
     this.inputs = new BaseRepository(InputEntity, "input", context);
     this.headers = new BaseRepository(HeaderEntity, "header", context);
     this.tokens = new BaseRepository(TokenEntity, "token", context);
+
+    this.unconfirmedTransactions = new UnconfirmedTransactionRepository(
+      UnconfirmedTransactionEntity,
+      "utx",
+      context
+    );
   }
 }

--- a/src/context/repository-interface.ts
+++ b/src/context/repository-interface.ts
@@ -1,0 +1,17 @@
+import { GraphQLResolveInfo } from "graphql";
+import { BaseEntity } from "typeorm";
+
+export type FindOneParams<T> = {
+  where?: Partial<T>;
+  resolverInfo?: GraphQLResolveInfo;
+};
+
+export type FindManyParams<T> = FindOneParams<T> & {
+  take?: number;
+  skip?: number;
+};
+
+export interface IRepository<T extends BaseEntity> {
+  find(options: FindManyParams<T>): Promise<T[]>;
+  first(options: FindOneParams<T>): Promise<T | null>;
+}

--- a/src/context/transactions-repository.ts
+++ b/src/context/transactions-repository.ts
@@ -8,7 +8,7 @@ type TransactionFindOptions = FindManyParams<TransactionEntity> & {
   toHeight?: number;
 };
 
-export class TransactionsRepository extends BaseRepository<TransactionEntity> {
+export class TransactionRepository extends BaseRepository<TransactionEntity> {
   public override async find(options: TransactionFindOptions): Promise<TransactionEntity[]> {
     return this.findBase(options, (query) => {
       const { fromHeight, toHeight } = options;
@@ -24,9 +24,7 @@ export class TransactionsRepository extends BaseRepository<TransactionEntity> {
     });
   }
 
-  public async countBy(options: {
-    where: { address: string; maxHeight?: number };
-  }): Promise<number> {
+  public async count(options: { where: { address: string; maxHeight?: number } }): Promise<number> {
     let inputsQuery = this.dataSource
       .getRepository(BoxEntity)
       .createQueryBuilder("box")

--- a/src/context/transactions-repository.ts
+++ b/src/context/transactions-repository.ts
@@ -1,6 +1,6 @@
 import { BoxEntity, InputEntity, TransactionEntity } from "../entities";
 import { removeUndefined } from "../utils";
-import { BaseRepository } from "./base-repository";
+import { BaseRepository, RepositoryDataContext } from "./base-repository";
 import { FindManyParams } from "./repository-interface";
 
 type TransactionFindOptions = FindManyParams<TransactionEntity> & {
@@ -9,6 +9,10 @@ type TransactionFindOptions = FindManyParams<TransactionEntity> & {
 };
 
 export class TransactionRepository extends BaseRepository<TransactionEntity> {
+  constructor(context: RepositoryDataContext) {
+    super(TransactionEntity, "tx", context);
+  }
+
   public override async find(options: TransactionFindOptions): Promise<TransactionEntity[]> {
     return this.findBase(options, (query) => {
       const { fromHeight, toHeight } = options;
@@ -43,7 +47,7 @@ export class TransactionRepository extends BaseRepository<TransactionEntity> {
     }
 
     const { count } = await this.repository
-      .createQueryBuilder("tx")
+      .createQueryBuilder(this.alias)
       .select("COUNT(DISTINCT(tx.transactionId))", "count")
       .innerJoin(
         `(${inputsQuery.getSql()} UNION ${outputsQuery.getSql()})`,

--- a/src/context/transactions-repository.ts
+++ b/src/context/transactions-repository.ts
@@ -1,0 +1,63 @@
+import { BoxEntity, InputEntity, TransactionEntity } from "../entities";
+import { removeUndefined } from "../utils";
+import { BaseRepository } from "./base-repository";
+import { FindManyParams } from "./repository-interface";
+
+type TransactionFindOptions = FindManyParams<TransactionEntity> & {
+  fromHeight?: number;
+  toHeight?: number;
+};
+
+export class TransactionsRepository extends BaseRepository<TransactionEntity> {
+  public override async find(options: TransactionFindOptions): Promise<TransactionEntity[]> {
+    return this.findBase(options, (query) => {
+      const { fromHeight, toHeight } = options;
+
+      if (fromHeight) {
+        query = query.andWhere(`${query.alias}.inclusionHeight > :fromHeight`, { fromHeight });
+      }
+      if (toHeight) {
+        query = query.andWhere(`${query.alias}.inclusionHeight < :toHeight`, { toHeight });
+      }
+
+      return query;
+    });
+  }
+
+  public async countBy(options: {
+    where: { address: string; maxHeight?: number };
+  }): Promise<number> {
+    let inputsQuery = this.dataSource
+      .getRepository(BoxEntity)
+      .createQueryBuilder("box")
+      .select("input.transactionId", "transactionId")
+      .leftJoin(InputEntity, "input", "box.boxId = input.boxId AND input.mainChain = true")
+      .where("box.mainChain = true AND box.address = :address");
+    let outputsQuery = this.dataSource
+      .getRepository(BoxEntity)
+      .createQueryBuilder("box")
+      .select("box.transactionId", "transactionId")
+      .where("box.mainChain = true AND box.address = :address");
+
+    if (options.where.maxHeight) {
+      inputsQuery = inputsQuery.andWhere("box.creationHeight <= :height");
+      outputsQuery = outputsQuery.andWhere("box.creationHeight <= :height");
+    }
+
+    const { count } = await this.repository
+      .createQueryBuilder("tx")
+      .select("COUNT(DISTINCT(tx.transactionId))", "count")
+      .innerJoin(
+        `(${inputsQuery.getSql()} UNION ${outputsQuery.getSql()})`,
+        "boxes",
+        '"boxes"."transactionId" = tx.transactionId'
+      )
+      .where("tx.mainChain = true")
+      .setParameters(
+        removeUndefined({ address: options.where.address, height: options.where.maxHeight })
+      )
+      .getRawOne();
+
+    return count;
+  }
+}

--- a/src/context/transactions-repository.ts
+++ b/src/context/transactions-repository.ts
@@ -10,7 +10,7 @@ type TransactionFindOptions = FindManyParams<TransactionEntity> & {
 
 export class TransactionRepository extends BaseRepository<TransactionEntity> {
   constructor(context: RepositoryDataContext) {
-    super(TransactionEntity, "tx", context);
+    super(TransactionEntity, "tx", context, { mainChain: true });
   }
 
   public override async find(options: TransactionFindOptions): Promise<TransactionEntity[]> {

--- a/src/context/unconfirmed-transactions-repository.ts
+++ b/src/context/unconfirmed-transactions-repository.ts
@@ -1,0 +1,22 @@
+import { UnconfirmedTransactionEntity } from "../entities";
+import { BaseRepository } from "./base-repository";
+
+export class UnconfirmedTransactionRepository extends BaseRepository<UnconfirmedTransactionEntity> {
+  public async count(): Promise<number> {
+    const { count } = await this.repository
+      .createQueryBuilder("utx")
+      .select("COUNT(utx.transactionId)", "count")
+      .getRawOne();
+
+    return count || 0;
+  }
+
+  public async sum(options: { by: "size" }) {
+    const { sum } = await this.repository
+      .createQueryBuilder("utx")
+      .select(`SUM(utx.${options.by})`, "sum")
+      .getRawOne();
+
+    return sum || 0;
+  }
+}

--- a/src/context/unconfirmed-transactions-repository.ts
+++ b/src/context/unconfirmed-transactions-repository.ts
@@ -1,10 +1,14 @@
 import { UnconfirmedTransactionEntity } from "../entities";
-import { BaseRepository } from "./base-repository";
+import { BaseRepository, RepositoryDataContext } from "./base-repository";
 
 export class UnconfirmedTransactionRepository extends BaseRepository<UnconfirmedTransactionEntity> {
+  constructor(context: RepositoryDataContext) {
+    super(UnconfirmedTransactionEntity, "utx", context);
+  }
+
   public async count(): Promise<number> {
     const { count } = await this.repository
-      .createQueryBuilder("utx")
+      .createQueryBuilder(this.alias)
       .select("COUNT(utx.transactionId)", "count")
       .getRawOne();
 
@@ -13,7 +17,7 @@ export class UnconfirmedTransactionRepository extends BaseRepository<Unconfirmed
 
   public async sum(options: { by: "size" }) {
     const { sum } = await this.repository
-      .createQueryBuilder("utx")
+      .createQueryBuilder(this.alias)
       .select(`SUM(utx.${options.by})`, "sum")
       .getRawOne();
 

--- a/src/graphql/context-type.ts
+++ b/src/graphql/context-type.ts
@@ -1,0 +1,9 @@
+import { DatabaseContext } from "../context/database-context";
+
+export type GraphQLContext = {
+  repository: DatabaseContext;
+};
+
+export type GraphQLContextWithArgs<T> = GraphQLContext & {
+  args: T;
+};

--- a/src/graphql/resolvers/address-resolver.ts
+++ b/src/graphql/resolvers/address-resolver.ts
@@ -1,15 +1,13 @@
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, FieldResolver, Info, Int, Query, Resolver } from "type-graphql";
-import { appDataSource } from "../../data-source";
-import {
-  AssetEntity,
-  BoxEntity,
-  InputEntity,
-  TokenEntity,
-  TransactionEntity
-} from "../../entities";
+import { GraphQLContextWithArgs } from "../context-type";
 import { Address } from "../objects/address";
 import { isFieldSelected } from "./utils";
+
+type ContextArgs = {
+  address: string;
+  atHeight?: number;
+};
 
 @Resolver(Address)
 export class AddressResolver {
@@ -17,7 +15,7 @@ export class AddressResolver {
   async addresses(
     @Arg("address", () => String, { nullable: false }) address: string,
     @Arg("atHeight", () => Int, { nullable: true }) atHeight: number,
-    @Ctx() context: { args: { address: string; atHeight: number } }
+    @Ctx() context: GraphQLContextWithArgs<ContextArgs>
   ) {
     context.args = { address, atHeight };
     return {};
@@ -25,76 +23,25 @@ export class AddressResolver {
 
   @FieldResolver()
   async balance(
-    @Ctx() context: { args: { address: string; atHeight: number } },
+    @Ctx() context: GraphQLContextWithArgs<ContextArgs>,
     @Info() info: GraphQLResolveInfo
   ) {
-    const repository = appDataSource.getRepository(BoxEntity);
-    let baseQuery = repository
-      .createQueryBuilder("box")
-      .leftJoinAndSelect(InputEntity, "input", "box.boxId = input.boxId")
-      .where("box.address = :address", { address: context.args.address })
-      .andWhere("input.boxId IS NULL");
-
-    if (context.args.atHeight) {
-      baseQuery = baseQuery.andWhere("box.creationHeight <= :height", {
-        height: context.args.atHeight
-      });
-    }
-
-    const { nanoErgs } = isFieldSelected(info, "nanoErgs")
-      ? await baseQuery.select("SUM(box.value)", "nanoErgs").getRawOne()
-      : 0;
-
-    const assets = isFieldSelected(info, "assets")
-      ? await baseQuery
-          .leftJoinAndSelect(AssetEntity, "asset", "box.boxId = asset.boxId")
-          .leftJoinAndSelect(TokenEntity, "token", "asset.tokenId = token.tokenId")
-          .andWhere("asset.tokenId IS NOT NULL")
-          .groupBy("asset.tokenId")
-          .addGroupBy("token.name")
-          .addGroupBy("token.decimals")
-          .select("sum(asset.value)", "amount")
-          .addSelect("asset.tokenId", "tokenId")
-          .addSelect("token.name", "name")
-          .addSelect("token.decimals", "decimals")
-          .getRawMany()
-      : [];
-
-    return { nanoErgs: nanoErgs ?? 0, assets };
+    return await context.repository.boxes.sum({
+      where: { address: context.args.address, maxHeight: context.args.atHeight },
+      include: {
+        nanoErgs: isFieldSelected(info, "nanoErgs"),
+        assets: isFieldSelected(info, "assets")
+      }
+    });
   }
 
   @FieldResolver()
-  async transactionsCount(@Ctx() context: { args: { address: string; atHeight: number } }) {
-    let inputsQuery = appDataSource
-      .getRepository(BoxEntity)
-      .createQueryBuilder("box")
-      .select("input.transactionId", "transactionId")
-      .leftJoin(InputEntity, "input", "box.boxId = input.boxId and input.mainChain = true")
-      .where("box.mainChain = true and box.address = :address");
-    let outputsQuery = appDataSource
-      .getRepository(BoxEntity)
-      .createQueryBuilder("box")
-      .select("box.transactionId", "transactionId")
-      .where("box.mainChain = true and box.address = :address");
-
-    if (context.args.atHeight) {
-      inputsQuery = inputsQuery.andWhere("box.creationHeight <= :height");
-      outputsQuery = outputsQuery.andWhere("box.creationHeight <= :height");
-    }
-
-    const { count } = await appDataSource
-      .getRepository(TransactionEntity)
-      .createQueryBuilder("tx")
-      .select("COUNT(DISTINCT(tx.transactionId))", "count")
-      .innerJoin(
-        `(${inputsQuery.getSql()} UNION ${outputsQuery.getSql()})`,
-        "boxes",
-        '"boxes"."transactionId" = tx.transactionId'
-      )
-      .where("tx.mainChain = true")
-      .setParameters({ address: context.args.address, height: context.args.atHeight })
-      .getRawOne();
-
-    return count;
+  async transactionsCount(@Ctx() context: GraphQLContextWithArgs<ContextArgs>) {
+    return await context.repository.transactions.countBy({
+      where: {
+        address: context.args.address,
+        maxHeight: context.args.atHeight
+      }
+    });
   }
 }

--- a/src/graphql/resolvers/address-resolver.ts
+++ b/src/graphql/resolvers/address-resolver.ts
@@ -37,7 +37,7 @@ export class AddressResolver {
 
   @FieldResolver()
   async transactionsCount(@Ctx() context: GraphQLContextWithArgs<ContextArgs>) {
-    return await context.repository.transactions.countBy({
+    return await context.repository.transactions.count({
       where: {
         address: context.args.address,
         maxHeight: context.args.atHeight

--- a/src/graphql/resolvers/block-resolver.ts
+++ b/src/graphql/resolvers/block-resolver.ts
@@ -1,11 +1,10 @@
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, Info, Query, Resolver } from "type-graphql";
 import { DEFAULT_SKIP } from "../../consts";
-import { BlockInfoEntity } from "../../entities";
 import { TakeAmountScalar } from "../scalars";
 import { removeUndefined } from "../../utils";
 import { Block } from "../objects/block";
+import { GraphQLContext } from "../context-type";
 
 @Resolver(Block)
 export class BlockResolver {
@@ -15,20 +14,14 @@ export class BlockResolver {
     @Arg("take", () => TakeAmountScalar, { defaultValue: 10 }) take: number,
     @Arg("headerId", () => String, { nullable: true }) headerId: string | undefined,
     @Arg("height", () => Number, { nullable: true }) height: number | undefined,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({
-      headerId,
-      height
+    return context.repository.blockInfo.find({
+      resolverInfo: info,
+      where: removeUndefined({ headerId, height }),
+      take,
+      skip
     });
-
-    return await context.loader
-      .loadEntity(BlockInfoEntity, "block")
-      .info(info)
-      .ejectQueryBuilder((query) => {
-        return query.where(where).skip(skip).take(take);
-      })
-      .loadMany();
   }
 }

--- a/src/graphql/resolvers/box-resolver.ts
+++ b/src/graphql/resolvers/box-resolver.ts
@@ -1,11 +1,10 @@
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, Info, Query, Resolver } from "type-graphql";
 import { DEFAULT_SKIP, MAX_TAKE } from "../../consts";
-import { BoxEntity } from "../../entities";
 import { Box } from "../objects";
 import { TakeAmountScalar } from "../scalars";
 import { removeUndefined } from "../../utils";
+import { GraphQLContext } from "../context-type";
 
 @Resolver(Box)
 export class BoxResolver {
@@ -20,24 +19,21 @@ export class BoxResolver {
     @Arg("ergoTree", () => String, { nullable: true }) ergoTree: string | undefined,
     @Arg("ergoTreeTemplateHash", () => String, { nullable: true })
     ergoTreeTemplateHash: string | undefined,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({
-      address,
-      boxId,
-      transactionId,
-      headerId,
-      ergoTree,
-      ergoTreeTemplateHash
+    return context.repository.boxes.find({
+      resolverInfo: info,
+      where: removeUndefined({
+        address,
+        boxId,
+        transactionId,
+        headerId,
+        ergoTree,
+        ergoTreeTemplateHash
+      }),
+      skip,
+      take
     });
-
-    return await context.loader
-      .loadEntity(BoxEntity, "box")
-      .info(info)
-      .ejectQueryBuilder((query) => {
-        return query.where(where).skip(skip).take(take);
-      })
-      .loadMany();
   }
 }

--- a/src/graphql/resolvers/data-input-resolver.ts
+++ b/src/graphql/resolvers/data-input-resolver.ts
@@ -1,11 +1,10 @@
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, Info, Query, Resolver } from "type-graphql";
 import { DEFAULT_SKIP, MAX_TAKE } from "../../consts";
-import { InputEntity } from "../../entities";
 import { DataInput } from "../objects/data-input";
 import { TakeAmountScalar } from "../scalars";
 import { removeUndefined } from "../../utils";
+import { GraphQLContext } from "../context-type";
 
 @Resolver(DataInput)
 export class DataInputResolver {
@@ -16,19 +15,18 @@ export class DataInputResolver {
     @Arg("transactionId", () => String, { nullable: true }) transactionId: string | undefined,
     @Arg("boxId", () => String, { nullable: true }) boxId: string | undefined,
     @Arg("headerId", () => String, { nullable: true }) headerId: string | undefined,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({
-      transactionId,
-      boxId,
-      headerId
+    return context.repository.dataInputs.find({
+      resolverInfo: info,
+      where: removeUndefined({
+        transactionId,
+        boxId,
+        headerId
+      }),
+      skip,
+      take
     });
-
-    return await context.loader
-      .loadEntity(InputEntity, "dataInput")
-      .info(info)
-      .ejectQueryBuilder((query) => query.where(where).skip(skip).take(take))
-      .loadMany();
   }
 }

--- a/src/graphql/resolvers/header-resolver.ts
+++ b/src/graphql/resolvers/header-resolver.ts
@@ -1,11 +1,10 @@
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, Info, Query, Resolver } from "type-graphql";
 import { DEFAULT_SKIP } from "../../consts";
-import { HeaderEntity } from "../../entities";
 import { Header } from "../objects";
 import { TakeAmountScalar } from "../scalars";
 import { removeUndefined } from "../../utils";
+import { GraphQLContext } from "../context-type";
 
 @Resolver(Header)
 export class HeaderResolver {
@@ -15,20 +14,17 @@ export class HeaderResolver {
     @Arg("take", () => TakeAmountScalar, { defaultValue: 10 }) take: number,
     @Arg("parentId", () => String, { nullable: true }) parentId: string | undefined,
     @Arg("height", () => Number, { nullable: true }) height: number | undefined,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({
-      parentId,
-      height
+    return context.repository.headers.find({
+      resolverInfo: info,
+      where: removeUndefined({
+        parentId,
+        height
+      }),
+      skip,
+      take
     });
-
-    return await context.loader
-      .loadEntity(HeaderEntity, "header")
-      .info(info)
-      .ejectQueryBuilder((query) => {
-        return query.where(where).skip(skip).take(take);
-      })
-      .loadMany();
   }
 }

--- a/src/graphql/resolvers/input-resolver.ts
+++ b/src/graphql/resolvers/input-resolver.ts
@@ -1,11 +1,10 @@
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, Info, Query, Resolver } from "type-graphql";
 import { DEFAULT_SKIP, MAX_TAKE } from "../../consts";
-import { InputEntity } from "../../entities";
 import { Input } from "../objects";
 import { TakeAmountScalar } from "../scalars";
 import { removeUndefined } from "../../utils";
+import { GraphQLContext } from "../context-type";
 
 @Resolver(Input)
 export class InputResolver {
@@ -16,19 +15,18 @@ export class InputResolver {
     @Arg("transactionId", () => String, { nullable: true }) transactionId: string | undefined,
     @Arg("boxId", () => String, { nullable: true }) boxId: string | undefined,
     @Arg("headerId", () => String, { nullable: true }) headerId: string | undefined,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({
-      transactionId,
-      boxId,
-      headerId
+    return context.repository.inputs.find({
+      resolverInfo: info,
+      where: removeUndefined({
+        transactionId,
+        boxId,
+        headerId
+      }),
+      skip,
+      take
     });
-
-    return await context.loader
-      .loadEntity(InputEntity, "input")
-      .info(info)
-      .ejectQueryBuilder((query) => query.where(where).skip(skip).take(take))
-      .loadMany();
   }
 }

--- a/src/graphql/resolvers/token-resolver.ts
+++ b/src/graphql/resolvers/token-resolver.ts
@@ -1,10 +1,9 @@
 import { GraphQLResolveInfo } from "graphql";
 import { Args, ArgsType, Ctx, Field, Info, Query, Resolver } from "type-graphql";
-import { TokenEntity } from "../../entities";
 import { Token } from "../objects";
 import { removeUndefined } from "../../utils";
 import { PaginationArguments } from "./pagination-arguments";
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
+import { GraphQLContext } from "../context-type";
 
 @ArgsType()
 class TokensQueryArgs {
@@ -21,15 +20,14 @@ export class TokenResolver {
   async tokens(
     @Args() { tokenId, boxId }: TokensQueryArgs,
     @Args({ validate: true }) { skip, take }: PaginationArguments,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({ tokenId, boxId });
-
-    return await context.loader
-      .loadEntity(TokenEntity, "token")
-      .info(info)
-      .ejectQueryBuilder((query) => query.where(where).skip(skip).take(take))
-      .loadMany();
+    return context.repository.tokens.find({
+      resolverInfo: info,
+      where: removeUndefined({ tokenId, boxId }),
+      skip,
+      take
+    });
   }
 }

--- a/src/graphql/resolvers/token-resolver.ts
+++ b/src/graphql/resolvers/token-resolver.ts
@@ -1,11 +1,10 @@
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, Info, Query, Resolver } from "type-graphql";
 import { DEFAULT_SKIP, MAX_TAKE } from "../../consts";
-import { TokenEntity } from "../../entities";
 import { Token } from "../objects";
 import { TakeAmountScalar } from "../scalars";
 import { removeUndefined } from "../../utils";
+import { GraphQLContext } from "../context-type";
 
 @Resolver(Token)
 export class TokenResolver {
@@ -14,15 +13,14 @@ export class TokenResolver {
     @Arg("skip", { defaultValue: DEFAULT_SKIP }) skip: number,
     @Arg("take", () => TakeAmountScalar, { defaultValue: MAX_TAKE }) take: number,
     @Arg("boxId", () => String, { nullable: true }) boxId: string | undefined,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({ boxId });
-
-    return await context.loader
-      .loadEntity(TokenEntity, "token")
-      .info(info)
-      .ejectQueryBuilder((query) => query.where(where).skip(skip).take(take))
-      .loadMany();
+    return context.repository.tokens.find({
+      resolverInfo: info,
+      where: removeUndefined({ boxId }),
+      skip,
+      take
+    });
   }
 }

--- a/src/graphql/resolvers/transaction-resolver.ts
+++ b/src/graphql/resolvers/transaction-resolver.ts
@@ -1,11 +1,10 @@
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { GraphQLResolveInfo } from "graphql";
 import { Arg, Ctx, Info, Query, Resolver } from "type-graphql";
 import { DEFAULT_SKIP, MAX_TAKE } from "../../consts";
-import { TransactionEntity } from "../../entities";
 import { Transaction } from "../objects/transaction";
 import { TakeAmountScalar } from "../scalars";
 import { removeUndefined } from "../../utils";
+import { GraphQLContext } from "../context-type";
 
 @Resolver(Transaction)
 export class TransactionResolver {
@@ -17,24 +16,16 @@ export class TransactionResolver {
     @Arg("toHeight", () => Number, { nullable: true }) toHeight: number | undefined,
     @Arg("headerId", () => String, { nullable: true }) headerId: string | undefined,
     @Arg("inclusionHeight", () => Number, { nullable: true }) inclusionHeight: number | undefined,
-    @Ctx() context: { loader: GraphQLDatabaseLoader },
+    @Ctx() context: GraphQLContext,
     @Info() info: GraphQLResolveInfo
   ) {
-    const where = removeUndefined({ headerId, inclusionHeight });
-
-    return await context.loader
-      .loadEntity(TransactionEntity, "transaction")
-      .info(info)
-      .ejectQueryBuilder((query) => {
-        query = query.where(where);
-
-        if (fromHeight)
-          query = query.andWhere("transaction.inclusionHeight > :fromHeight", { fromHeight });
-        if (toHeight)
-          query = query.andWhere("transaction.inclusionHeight < :toHeight", { toHeight });
-
-        return query.skip(skip).take(take);
-      })
-      .loadMany();
+    return await context.repository.transactions.find({
+      resolverInfo: info,
+      where: removeUndefined({ headerId, inclusionHeight }),
+      take,
+      skip,
+      fromHeight,
+      toHeight
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import "./prototypes";
 
 import { simpleEstimator, fieldExtensionsEstimator } from "graphql-query-complexity";
 import { createComplexityPlugin } from "graphql-query-complexity-apollo-plugin";
-import GraphQLDatabaseLoader from "@mando75/typeorm-graphql-loader";
 import { ApolloServer } from "apollo-server";
 import { initializeDataSource } from "./data-source";
 import { GraphQLSchema } from "graphql";
@@ -16,6 +15,7 @@ import { redisClient } from "./caching";
 import { blockWatcher } from "./block-watcher";
 import { ApolloServerPluginCacheControl } from "apollo-server-core";
 import { MAX_CACHE_AGE, DEFAULT_MAX_QUERY_COMPLEXITY } from "./consts";
+import { DatabaseContext } from "./context/database-context";
 
 const { TS_NODE_DEV, MAX_QUERY_COMPLEXITY } = process.env;
 
@@ -29,7 +29,7 @@ async function startServer(schema: GraphQLSchema, dataSource: DataSource) {
   const server = new ApolloServer({
     csrfPrevention: true,
     schema,
-    context: { loader: new GraphQLDatabaseLoader(dataSource) },
+    context: { repository: new DatabaseContext(dataSource) },
     plugins: [
       createComplexityPlugin({
         schema,


### PR DESCRIPTION
This PR abstracts data layer into proper context classes.

- `BaseRepository` is used for generic repositories and has basic queries implementations for `find()`, for many entities result, and `first()`, for a single entity result.
- If complex queries are needed, a new repository class can be created (see `TransactionsRepository` and `BoxRepository` as example)
- All repositories are grouped into `DatabaseContext` which instantiated in GraphQL context param.